### PR TITLE
Prop Type depreciation fix for React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mocha": "^3.2.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "prop-types": "^15.5.8",
     "standard": "^9.0.0",
     "test-console": "^1.0.0",
     "webpack": "^2.2.1"

--- a/src/Lowlight.js
+++ b/src/Lowlight.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var React = require('react')
+var PropTypes = require('prop-types')
 var low = require('lowlight/lib/core')
 var mapChildren = require('./mapChildren')
 var h = React.createElement
@@ -38,12 +39,12 @@ function Lowlight (props) {
 }
 
 Lowlight.propTypes = {
-  className: React.PropTypes.string,
-  inline: React.PropTypes.bool,
-  language: React.PropTypes.string,
-  prefix: React.PropTypes.string,
-  subset: React.PropTypes.arrayOf(React.PropTypes.string),
-  value: React.PropTypes.string.isRequired
+  className: PropTypes.string,
+  inline: PropTypes.bool,
+  language: PropTypes.string,
+  prefix: PropTypes.string,
+  subset: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.string.isRequired
 }
 
 Lowlight.defaultProps = {


### PR DESCRIPTION
React 15.5 will warn users that PropTypes is being moved to its own
module. This will fix the warning and should work when React 16 lands.