### PR TITLE
Fix array-based className handling to avoid comma separation in child elements

### DIFF
--- a/src/mapChildren.js
+++ b/src/mapChildren.js
@@ -3,6 +3,11 @@ import { createElement } from 'react'
 function mapChild (child, i, depth) {
   if (child.tagName) {
     const props = Object.assign({ key: 'lo-' + depth + '-' + i }, child.properties)
+
+    if (Array.isArray(props.className)) {
+      props.className = props.className.join(' ')
+    }
+
     const children = child.children ? child.children.map(mapWithDepth(depth + 1)) : null
 
     return createElement(child.tagName, props, children)

--- a/test/Lowlight.test.js
+++ b/test/Lowlight.test.js
@@ -86,6 +86,14 @@ describe('react-lowlight', () => {
       ].join('')
     )
   })
+
+  it('should properly join array-based class names in child elements', () => {
+    const code = 'function foo() {}'
+
+    expect(render({ value: code, language: 'js' }, { withWrapper: true })).toBe(
+      '<pre class="lowlight"><code class="hljs js"><span class="hljs-keyword">function</span> <span class="hljs-title function_">foo</span>(<span class="hljs-params"></span>) {}</code></pre>'
+    )
+  })
 })
 
 function render (props, options = {}) {


### PR DESCRIPTION
Hey there! First, thanks so much for all the work required to build and maintain this library. 

When integrating it into my blog, I noticed that class names were not being applied correctly. Specifically, when child elements receive an array of class names  (e.g., `["hljs-title", "function_"]`), React currently renders them as a comma-separated string (`"hljs-title,function_"`), which brakes CSS. This issue can be seen on the provided demo page as well:

![CleanShot 2024-12-28 at 17 23 41@2x](https://github.com/user-attachments/assets/4939b2ba-33ee-45f9-bb1a-9ca33fd59924)

This PR ensures that any `className` arrays are joined with spaces (`"hljs-title function_"`) instead.

![CleanShot 2024-12-28 at 17 23 52@2x](https://github.com/user-attachments/assets/d6374304-6b9b-4a3e-a212-260436f95ed3)

### Changes
1. `mapChild` function checks if `props.className` is an array, and if so, joins it with a space.
2. The expected behavior is covered with a separate test. All existing tests pass without regression.