### PR TITLE
fix: LowlightMarker types - `Type 'string' is not assignable to type 'number'`

### DIFF
--- a/src/Lowlight.d.ts
+++ b/src/Lowlight.d.ts
@@ -1,6 +1,6 @@
 interface LowlightMarker {
     line: number;
-    className?: number;
+    className?: string;
 }
 interface LowlightProps {
     className?: string;


### PR DESCRIPTION
`LowlightMarker.className` is typed as number, but should be a string

Causes `Type 'string' is not assignable to type 'number'.` error in TS projects

<img width="1301" height="182" alt="image" src="https://github.com/user-attachments/assets/0cce12df-962d-4fef-93e3-d3f3f2c62e8d" />
